### PR TITLE
install pika==0.13.1

### DIFF
--- a/hamgr/container/Dockerfile
+++ b/hamgr/container/Dockerfile
@@ -11,7 +11,7 @@ RUN apk add gcc
 RUN apk add g++
 RUN apk add dpkg
 RUN apk add musl-dev
-
+RUN apk add openssl
 RUN apk add mariadb \
      mariadb-client \
      --no-cache mariadb-dev \

--- a/hamgr/container/init-region
+++ b/hamgr/container/init-region
@@ -87,10 +87,9 @@ class HamgrConfig:
         rabbit_config = {
             'username': 'hamgr',
             'password': password,
-            'config': '^(pf9-changes)$',
-            'write': '^(pf9-changes)$',
-            'read': '^$',
-            'tags': 'administrator'
+            'config': '.*',
+            'write': '.*',
+            'read': '.*'
         }
         self._consul.kv_put_txn(
             {f'{prefix}{key}': value for prefix in [hamgr_amqp_prefix, rabbit_broker_hamgr_prefix] for key, value in

--- a/hamgr/container/requirements.txt
+++ b/hamgr/container/requirements.txt
@@ -14,5 +14,5 @@ eventlet
 sqlalchemy-migrate
 mysqlclient==1.4.6
 enum34
-pika
+pika==0.13.1
 cryptography


### PR DESCRIPTION
pika version change fixes ampqp connection error in hamgr :
```
2024-06-16 07:22:31,358 DEBG 'hamgr' stderr output:
  self.run()
 File "/usr/local/lib/python3.9/threading.py", line 917, in run
  self._target(*self._args, **self._kwargs)
 File "/usr/local/lib/python3.9/site-packages/shared/rpc/rpc_channel.py", line 201, in _run
  self._close_connection()
 File "/usr/local/lib/python3.9/site-packages/shared/rpc/rpc_channel.py", line 88, in _close_connection
  self._connection.close()
 File "/usr/local/lib/python3.9/site-packages/pika/connection.py", line 1304, in close
  raise exceptions.ConnectionWrongStateError(msg)
pika.exceptions.ConnectionWrongStateError: Illegal close(200, 'Normal shutdown') request on <SelectConnection CLOSED transport=None params=<ConnectionParameters host=localhost port=5672 virtual_host=/ ssl=False>> because it was called while connection state=CLOSED.
```

