### PR TITLE
PCD-217: limit VM-HA to Availability Zone Instead of Host Aggregate

### DIFF
--- a/hamgr/README.md
+++ b/hamgr/README.md
@@ -5,58 +5,60 @@ This service sets up the high availability (HA) node cluster
 All Data is exchanged in JSON format
 
 ## API ##
-GET /v1/ha/<aggregate_id>
+GET /v1/ha
 
-Returns the HA configuration state for the host aggregate
+Returns the HA configuration state for the all availability zones
 
 Example:
 ```
 {
     "status":
     [
-     { "id": 1, "state": "enabled" },
+     { "enabled": true, "name": "nova", "task_state": "completed" },
+     { "enabled": true, "name": "compute-az", "task_state": "completed" }
     ]
 }
 ```
 
 HA configuration requires a minimum of three hosts. It is said to be
-non-available if the aggregate has less than three hosts.
+non-available if the availability zone has less than three hosts.
 
-GET /v1/ha/\<aggregate_id>
+GET /v1/ha/<availability_zone>
 
-Returns HA configuration state for one host aggregate
+Returns HA configuration state for one availability zone
 
 Example:
 ```
 {
-    "status":
-    [
-     { "id": 1, "state": "enabled" },
-     { "id": 11, "state": "disabled" },
-     { "id": 14, "state": "not-available" }
-    ]
+  "status": [
+    {
+      "enabled": true,
+      "name": "nova",
+      "task_state": "completed"
+    }
+  ]
 }
 ```
 
 
-PUT /v1/ha/\<aggregate_id>/enable
+PUT /v1/ha/<availability_zone>/enable
 
-Activates the HA configuration on all hosts in the given aggregate.
-1. If HA is not yet enabled for given aggregate:  The eligible hosts are determined by looking at their
-host aggregate metadata. All hosts in the host aggregate are treated as one HA cluster
-2. If HA is already enabled for given aggregate: No action is performed.
-3. If HA cannot be enabled for given aggregate: This can happen if there are
-less than three hosts in the host aggregate. The API fails in such a case.
+Activates the HA configuration on all hosts in the given availability zone.
+1. If HA is not yet enabled for given availability zone:  The eligible hosts are determined by looking at their
+host availability zone metadata. All hosts in the availability zone are treated as one HA cluster
+2. If HA is already enabled for given availability zone: No action is performed.
+3. If HA cannot be enabled for given availability zone: This can happen if there are
+less than three hosts in the availability zone. The API fails in such a case.
 
-PUT /v1/ha/\<aggregate_id>/disable
+PUT /v1/ha/<availability_zone>/disable
 
-Disables HA for an aggregate. With following possible outcomes --
-1. If given aggregate is HA enabled, it is disabled. The clustering
+Disables HA for an availability zone. With following possible outcomes --
+1. If given availability zone is HA enabled, it is disabled. The clustering
 services are removed from all participating hosts.
-2. If the aggregate has HA disabled, no action is taken.
-3. If the aggregate was not found, the API reports failure.
+2. If the availability zone has HA disabled, no action is taken.
+3. If the availability zone was not found, the API reports failure.
 
-Once an aggregate is HA enabled, the hosts added to such aggregate
+Once an availability zone is HA enabled, the hosts added to such availability zone
 are automatically added to HA cluster services.
 
 

--- a/hamgr/container/etc/confd/templates/hamgr.conf
+++ b/hamgr/container/etc/confd/templates/hamgr.conf
@@ -48,7 +48,7 @@ masakari_endpoint = http://masakari-api.{{getenv "NAMESPACE"}}.svc.cluster.local
 region = {{getv "/region_id"}}
 
 [log]
-level = DEBUG
+level = INFO
 location = /var/log/pf9/hamgr/hamgr.log
 rotate_count = 5
 rotate_size = 10485760

--- a/hamgr/hamgr/common/key_helper.py
+++ b/hamgr/hamgr/common/key_helper.py
@@ -67,7 +67,7 @@ def clean_openssl_index_db():
 
 def get_consul_gossip_encryption_key(cluster_name="", seed=""):
     # the key is composed with starting magic code 'pf9-dc'
-    # and the cluster name (host aggregate id), if longer
+    # and the cluster name (availability zone name), if longer
     # than require 16 bytes, then trim it, when shorter ,
     # append 0 until length is 16
     str_name = "-" + str(cluster_name)

--- a/hamgr/hamgr/db/api.py
+++ b/hamgr/hamgr/db/api.py
@@ -553,14 +553,14 @@ def update_processing_event_with_notification(event_uuid, notification_uuid,
         return None
 
 
-def get_latest_consul_status(aggregate_id=None):
+def get_latest_consul_status(availability_zone=None):
     with dbsession() as session:
         try:
             records = []
             query = session.query(ConsulStatusInfo)
-            if aggregate_id is not None:
-                # the passed in aggregate_id maps to clusterName in hamgr db
-                query = query.filter_by(clusterName=str(aggregate_id))
+            if availability_zone is not None:
+                # the passed in availability_zone maps to clusterName in hamgr db
+                query = query.filter_by(clusterName=availability_zone)
                 query = query.order_by(ConsulStatusInfo.lastUpdate.desc())
                 records.append(query.first())
             else:

--- a/hamgr/hamgr/providers/provider.py
+++ b/hamgr/hamgr/providers/provider.py
@@ -21,19 +21,19 @@ class Provider(object):
 
     """Interface to HA manager provider."""
     @abstractmethod
-    def get(self, aggregate_id):
-        """Get the HA config status for given aggregate
+    def get(self, availability_zone):
+        """Get the HA config status for given availability_zone
 
-        :param aggregate_id: If none, returns all
+        :param availability_zone: If none, returns all
         :return: 'enabled'/'disabled'/'not-applicable'
         """
         pass
 
     @abstractmethod
-    def put(self, aggregate_id, method):
-        """Enable/disable HA for an aggregate
+    def put(self, availability_zone, method):
+        """Enable/disable HA for an availability_zone
 
-        :param aggregate_id:
+        :param availability_zone:
         :param method: enable/disable
         :return:
         """

--- a/hamgr/hamgr/server.py
+++ b/hamgr/hamgr/server.py
@@ -57,8 +57,8 @@ def start_server(conf, paste_ini):
         provider = provider_factory.ha_provider()
         LOG.debug('add task process_consul_encryption_configuration')
         periodic_task.add_task(provider.process_consul_encryption_configuration, 60, run_now=True)
-        LOG.debug('add task process_host_aggregate_changes')
-        periodic_task.add_task(provider.process_host_aggregate_changes, 60, run_now=True)
+        LOG.debug('add task process_availability_zone_changes')
+        periodic_task.add_task(provider.process_availability_zone_changes, 60, run_now=True)
         # dedicated task to handle host events
         LOG.debug('add task process_host_events')
         periodic_task.add_task(provider.process_host_events, 60, run_now=True)

--- a/shared/exceptions/ha_exceptions.py
+++ b/shared/exceptions/ha_exceptions.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 
-class AggregateNotFound(Exception):
-    def __init__(self, aggregate):
-        message = 'Aggregate %s not found' % aggregate
-        super(AggregateNotFound, self).__init__(message)
+class AvailabilityZoneNotFound(Exception):
+    def __init__(self, availability_zone):
+        message = 'Availability Zone %s not found' % availability_zone
+        super(AvailabilityZoneNotFound, self).__init__(message)
 
 
 class ClusterExists(Exception):


### PR DESCRIPTION
### **SUMMARY**

Updated VMHA apis to create HA cluster and masakari failover segment at AZ level instead of host aggregate. Any new host addition or removal from AZ will update the HA cluster state. 

### **TESTING DONE**

Created 2 aggregates each having 2 hosts in it with same AZ (nova). 

- **Enable HA**:  
    

> curl -k -X PUT -H "X-Auth-Token: $TOKEN"  -i https://az-ha- 
>     r2.platform9.horse/hamgr/v1/ha/nova/enable`

   After HA is enabled (HA cluster created, pf9-ha-slave role pushed to all hosts in the AZ)
   

> curl -k  -H "X-Auth-Token: $TOKEN"  -i https://az-ha- 
>    r2.platform9.horse/hamgr/v1/ha/nova
>    {
>    "status": [
>     {
>        "enabled": true,
>        "name": "nova",
>        "task_state": "completed"
>     }
>    ]
>   }


   HA cluster details: 
 

>  curl -k  -H "X-Auth-Token: $TOKEN"  -i https://az-ha- 
>   r2.platform9.horse/hamgr/v1/cluster
>  [
>    {
>      "created_at": "Wed, 13 Nov 2024 06:13:37 GMT",
>      "enabled": true,
>      "hosts": [
>        {
>          "on_maintenance": false,
>        "uuid": "453f64b7-a861-45c0-92e9-f0222ac9371b"
>        },
>        {
>          "on_maintenance": false,
>          "uuid": "59f57c00-4f0c-4179-93c6-f3a03d33fad2"
>        },
>        {
>          "on_maintenance": false,
>          "uuid": "ca5e95d3-2480-485d-a70f-2b913eb4edbf"
>        },
>        {
>          "on_maintenance": false,
>          "uuid": "f54ce615-8c49-4537-9608-70bc9f911304"
>        }
>      ],
>      "id": 3,
>     "name": "nova",
>      "status": "enabled"
>    }
>   ]

 
- **Adding new hosts to AZ:**  Hamgr added newly added hosts to the cluster and 
   pushed pf9-ha-slave role to the host. 
    Now cluster has 5 hosts
  

> curl -k  -H "X-Auth-Token: $TOKEN"  -i https://az-ha- 
>    r2.platform9.horse/hamgr/v1/cluster
>   [
>    {
>      "created_at": "Wed, 13 Nov 2024 06:13:37 GMT",
>      "enabled": true,
>      "hosts": [
>        {
>          "on_maintenance": false,
>         "uuid": "9c5df25f-e449-4ec6-97b6-3d40b3da246c"
>        },
>        {
>          "on_maintenance": false,
>          "uuid": "453f64b7-a861-45c0-92e9-f0222ac9371b"
>        },
>        {
>          "on_maintenance": false,
>          "uuid": "59f57c00-4f0c-4179-93c6-f3a03d33fad2"
>        },
>       {
>          "on_maintenance": false,
>          "uuid": "ca5e95d3-2480-485d-a70f-2b913eb4edbf"
>        },
>        {
>          "on_maintenance": false,
>          "uuid": "f54ce615-8c49-4537-9608-70bc9f911304"
>        }
>      ],
>      "id": 3,
>      "name": "nova",
>      "status": "enabled"
>    }
>  ]

 hamgr logs: 
 

> 2024-11-13 07:37:49,182 vmha.hamgr.providers.nova INFO assign ha-slave role for 
>  hosts which is missing pf9-ha-slave: 9c5df25f-e449-4ec6-97b6-3d40b3da246c
>  2024-11-13 07:37:49,283 vmha.hamgr.providers.nova INFO authorize pf9-ha-slave during adding new hosts: ['9c5df25f-e449-4ec6-97b6-3d40b3da246c']

 

- **Host-down**: Suspended one of the hosts having VM running on it. Hamgr detected inactive hosts after 3-5 mins and Masakari host down notification is generated. Masakari called the evacuate task and VM got migrated to one of the available hosts. 

- **Host-up** :  after resuming suspended hosts compute service was enabled by hamgr. 

- **Removal of host from AZ**:  After removing hosts from AZ hamgr removed the corresponding host from the HA cluster so pf9-ha-slave accordingly masakri segment is updated. 
