### PR TITLE
Allow disabling ha if it's in waiting state to enable HA

### DIFF
--- a/shared/constants.py
+++ b/shared/constants.py
@@ -59,13 +59,14 @@ RPC_TASK_STATE_FINISHED = 'finished'
 # Blank i.e. NULL task state means that the task was completed. Hence the
 # valid task states are only creating, deleting, updating and error-removing.
 
+TASK_WAITING = 'waiting'
 TASK_CREATING = 'creating'
 TASK_REMOVING = 'removing'
 TASK_MIGRATING = 'migrating'
 TASK_COMPLETED = None
 TASK_ERROR_REMOVING = 'error-removing'
-VALID_TASK_STATES = [TASK_CREATING, TASK_MIGRATING, TASK_REMOVING,
-                     TASK_COMPLETED, TASK_ERROR_REMOVING]
+VALID_TASK_STATES = [TASK_WAITING, TASK_CREATING, TASK_MIGRATING, 
+                     TASK_REMOVING, TASK_COMPLETED, TASK_ERROR_REMOVING]
 
 CONSUL_ROLE_SERVER = 'server'
 CONSUL_ROLE_CLIENT = 'client'


### PR DESCRIPTION
Added new task_state `waiting`.
When ha enable request is sent for an AZ and if AZ has < 4 hosts task_state will be waiting (unlike creating as earlier)and hamgr will allow disabling the HA in this state. 
i.e
```
root@hatest-1:~# curl -k -H "X-Auth-Token: $TOKEN" https://az-ha-r3.platform9.horse/hamgr/v1/ha
{
  "status": [
    {
      "enabled": false,
      "name": "nova",
      "task_state": "waiting"
    }
  ]
}
```
Once AZ has >=4 hosts it will update the task_state to creating further flow is the same as earlier. 

