### PR TITLE
PCD-461: add liveness probe to restart hamgr in case of db connection…

### DIFF
--- a/hamgr/container/Dockerfile
+++ b/hamgr/container/Dockerfile
@@ -27,6 +27,7 @@ COPY dbmigrate.py /usr/local/lib/python3.9/site-packages/hamgr/dbmigrate.py
 COPY hamgr-sdist.tgz \
      requirements.txt \
      /root/
+COPY liveness_probe.py /root/
 
 COPY init-region .
 RUN chmod 755 init-region

--- a/hamgr/container/liveness_probe.py
+++ b/hamgr/container/liveness_probe.py
@@ -1,0 +1,53 @@
+from keystoneauth1 import session 
+from keystoneauth1.identity import v3
+from six.moves.configparser import ConfigParser
+import logging
+import requests
+import subprocess
+import sys
+
+# configure logging
+logs_format = '[%(asctime)s] %(levelname)s - %(message)s'
+logger = logging.getLogger()
+# this is needed in order to see the logs through K8s logs
+handler = logging.FileHandler('/var/log/pf9/haprobe.log', mode='w')
+logger.setLevel(logging.DEBUG)
+formatter = logging.Formatter(logs_format)
+handler.setFormatter(formatter)
+logger.addHandler(handler)
+ 
+def load_config(config_file):
+    config = ConfigParser()
+    config.read(config_file)
+    return config
+
+def get_keystone_session():
+    config = load_config("/etc/pf9/hamgr/hamgr-api-paste.ini")
+    auth = v3.Password(
+        auth_url = config.get('filter:authtoken', 'auth_url'),
+        username = config.get('filter:authtoken', 'username'),
+        password = config.get('filter:authtoken', 'password'),
+        project_name = config.get('filter:authtoken', 'project_name'),
+        user_domain_id = config.get('filter:authtoken', 'user_domain_id'),
+        project_domain_id = config.get('filter:authtoken', 'project_domain_id'))
+    return session.Session(auth=auth)
+
+if __name__ == "__main__":
+    config = load_config("/etc/pf9/hamgr/hamgr.conf")
+    sess = get_keystone_session()
+    auth_ref = sess.auth.get_auth_ref(sess)
+    catalog = auth_ref.service_catalog.get_endpoints(service_type='hamgr', interface='internal',region_name=config.get('DEFAULT', 'region_name'), service_name='hamgr' )
+    hamgr_endpoint = catalog['hamgr'][0]['url']
+    token = sess.get_token()
+    HAMGR_URL = hamgr_endpoint + 'v1/ha'
+    headers = {"X-AUTH-TOKEN": token}
+    response = requests.get(HAMGR_URL, headers=headers)
+    data = response.json()
+    if response.status_code == 200:
+        if data["status"] == None:
+            result = subprocess.run(['supervisorctl', 'restart', 'hamgr'], capture_output=True, text=True)
+            logger.info(result.stdout)
+    else: 
+        logger.error(f"Failed to connect hamgr")
+        sys.exit(1)
+    sys.exit(0)


### PR DESCRIPTION
Calling `curl -k -H "X-Auth-Token: $TOKEN" https://$DU_FQDN/hamgr/v1/ha `api and comparing response if None restart the hamgr. 
The response is null (None) if the hamgr is not functional. 

Validated with db connection failure. 
#response when hamgr isn't functional
```
root@ce-936-1:~# curl -k -H "X-Auth-Token: $TOKEN"  https://cloud-region1.platform9.io/hamgr/v1/ha
{
  "status": null
}
```

#response when hamgr working fine
```
root@ce-936-1:~# curl -k -H "X-Auth-Token: $TOKEN"  https://cloud-region1.platform9.io/hamgr/v1/ha
{
  "status": [
    {
      "enabled": false,
      "name": "testaz",
      "task_state": null
    }
  ]
}
```

#response when hamgr functional and no ha entry available
```
root@ce-936-1:~# curl -k -H "X-Auth-Token: $TOKEN"  https://cloud-region1.platform9.io/hamgr/v1/ha
{
  "status": []
}
```