### PR TITLE
Switch logging to stdout

### DIFF
--- a/hamgr/container/etc/supervisord.conf
+++ b/hamgr/container/etc/supervisord.conf
@@ -5,11 +5,12 @@
 logfile=/var/log/supervisord.log
 logfile_maxbytes=50MB
 logfile_backups=10
-loglevel=debug
+loglevel=info
 pidfile=/var/run/supervisord.pid
 nodaemon=true
 minfds=1024
 minprocs=200
+capture_output=false
 
 [unix_http_server]
 file=/var/run/supervisor.sock
@@ -26,9 +27,10 @@ autostart=true
 autorestart=true
 startretries=99
 startsecs=1
-redirect_stderr=false
-stderr_logfile=/var/log/pf9/hamgr/hamgr-err.log
-stdout_logfile=/var/log/pf9/hamgr/hamgr.log
+redirect_stderr=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stdout_capture_maxbytes=0
 user=root
 killasgroup=true
 stopasgroup=true
@@ -37,7 +39,9 @@ stopasgroup=true
 [program:confd]
 command=confd -backend consul -node %(ENV_CONFIG_HOST_AND_PORT)s -scheme %(ENV_CONFIG_SCHEME)s -auth-token %(ENV_CONSUL_HTTP_TOKEN)s -watch -prefix /customers/%(ENV_CUSTOMER_ID)s/regions/%(ENV_REGION_ID)s
 redirect_stderr=true
-stdout_logfile=/var/log/confd/confd.log
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stdout_capture_maxbytes=0
 autorestart=true
 startretries=99
 startsecs=1

--- a/hamgr/hamgr/logger.py
+++ b/hamgr/hamgr/logger.py
@@ -31,45 +31,25 @@ def setup_root_logger(conf=None):
             with open(hamgr.DEFAULT_CONF_FILE) as fp:
                 conf.readfp(fp)
 
-    log_file = hamgr.DEFAULT_LOG_FILE
-    if conf.has_option("log", "location"):
-        log_file = conf.get("log", "location")
-
     log_level = hamgr.DEFAULT_LOG_LEVEL
     if conf.has_option("log", "level"):
         log_level = conf.get("log", "level")
-    log_mode = 'a'
-    log_rotate_count = hamgr.DEFAULT_ROTATE_COUNT
-    if conf.has_option("log", "rotate_count"):
-        log_rotate_count = conf.get("log", "rotate_count")
-    log_rotate_size = hamgr.DEFAULT_ROTATE_SIZE
-    if conf.has_option("log", "rotate_size"):
-        log_rotate_size = conf.get("log", "rotate_size")
+    
     log_format = logging.Formatter('%(asctime)s %(name)s %(levelname)s %(message)s')
 
     logger = logging.getLogger(ROOT_LOGGER)
     logger.setLevel(log_level)
 
-    # to mitigate the drawback of linux built-in log rotation which runs just once a day
-    # let the RotatingFileHandler to rotate the log , the built-in log rotation will do
-    # daily clean up and archives
-    handler = logging.handlers.RotatingFileHandler(log_file,
-                                                   mode=log_mode,
-                                                   maxBytes=int(log_rotate_size),
-                                                   backupCount=int(log_rotate_count))
-    handler.setLevel(log_level)
-    handler.setFormatter(log_format)
+    # Clear existing handlers
     for hdl in logger.handlers:
         logger.removeHandler(hdl)
-    logger.addHandler(handler)
+    
+    # Only add a StreamHandler to write logs to stdout
+    stdout_handler = logging.StreamHandler()
+    stdout_handler.setLevel(log_level)
+    stdout_handler.setFormatter(log_format)
+    logger.addHandler(stdout_handler)
 
-    try:
-        if dirname(log_file) != '' and not exists(dirname(log_file)):
-            makedirs(dirname(log_file))
-    except Exception as e:
-        logger.exception(e)
-        raise
-    logger.info('root logger created : name - %s, level - %s, file - %s, '
-                 'size - %s, backups - %s', ROOT_LOGGER, str(log_level),
-                 log_file, str(log_rotate_size), str(log_rotate_count))
+    logger.info('root logger created : name - %s, level - %s, stdout only', 
+                 ROOT_LOGGER, str(log_level))
     return logger

--- a/hamgr/hamgr/tests/test_logger.py
+++ b/hamgr/hamgr/tests/test_logger.py
@@ -24,41 +24,24 @@ FILE = "log.txt"
 
 
 class LogConfigTest(unittest.TestCase):
-    def _clean(self):
-        if os.path.exists(FILE):
-            logs = glob.glob("%s*" % FILE)
-            for log in logs:
-                os.remove(log)
-
     def setUp(self):
-        self._clean()
         conf = ConfigParser()
         conf.add_section("log")
-        conf.set("log", "location", FILE)
-        conf.set("log", "rotate_counts", '5')
-        conf.set("log", "rotate_size", '1024')
         conf.set("log", "level", "DEBUG")
         global LOG
         LOG = logger.setup_root_logger(conf=conf)
 
     def tearDown(self):
-        self._clean()
         pass
 
-    def test_logfile_created(self):
-        LOG.debug('in testing')
-        self.assertTrue(os.path.exists(FILE),
-                        'log file %s does not exist' % FILE)
-
-    def test_logfile_rotated(self):
-        for i in range(20000):
-            LOG.debug('This is test log line %d' % i)
-
-        self.assertTrue(os.path.exists(FILE))
-        logs = glob.glob("%s*" % FILE)
-        self.assertIsNotNone(logs)
-        self.assertTrue(len(logs) >= 1)
-        for log in logs:
-            size=os.path.getsize(log)
-            LOG.debug('size of file %s : %s', log, str(size))
-            self.assertTrue(size <= 1024)
+    def test_stdout_handler_added(self):
+        # Verify that a StreamHandler is added to the logger
+        handlers = LOG.handlers
+        stream_handlers = [h for h in handlers if isinstance(h, logger.logging.StreamHandler)]
+        self.assertTrue(len(stream_handlers) > 0, 'No StreamHandler found in logger handlers')
+        
+    def test_no_file_handlers(self):
+        # Verify that there are no file handlers
+        handlers = LOG.handlers
+        file_handlers = [h for h in handlers if isinstance(h, logger.logging.handlers.RotatingFileHandler)]
+        self.assertEqual(len(file_handlers), 0, 'Found file handlers when only stdout should be used')

--- a/host/ha/utils/log.py
+++ b/host/ha/utils/log.py
@@ -39,14 +39,16 @@ def setup_root_logger():
     logger = logging.getLogger(ROOT_LOGGER)
     logger.setLevel(LOG_LEVEL)
     formatter = logging.Formatter('%(asctime)s %(name)s %(levelname)s %(message)s')
-    handler = logging.handlers.RotatingFileHandler(LOG_FILE,
-                                                   mode='a',
-                                                   maxBytes=LOG_MAX_BYTES,
-                                                   backupCount=LOG_BACKUP_COUNT)
-    handler.setLevel(logging.DEBUG)
-    handler.setFormatter(formatter)
+    
+    # Clear existing handlers
     for hdl in logger.handlers:
         logger.removeHandler(hdl)
-    logger.addHandler(handler)
-    logger.info('root logger created : name - %s , level - %s', ROOT_LOGGER, LOG_LEVEL)
+    
+    # Only add a StreamHandler to write logs to stdout
+    stdout_handler = logging.StreamHandler()
+    stdout_handler.setLevel(logging.DEBUG)
+    stdout_handler.setFormatter(formatter)
+    logger.addHandler(stdout_handler)
+    
+    logger.info('root logger created : name - %s , level - %s, stdout only', ROOT_LOGGER, LOG_LEVEL)
     return logger


### PR DESCRIPTION
This change switches the logging location from /var/log/pf9/hamgr/hamgr.log in the container to stdout. This allows us to capture the logs using `kubectl logs` and other logging aggregators.