### PR TITLE
PCD-818 fix filter when searching for volumes in down host

### DIFF
--- a/hamgr/hamgr/providers/cinder.py
+++ b/hamgr/hamgr/providers/cinder.py
@@ -185,7 +185,7 @@ class CinderProvider(Provider):
                 
                 services_project = None
                 for project in keystone.projects.list():
-                    if project.name == 'service':
+                    if project.name == 'services':
                         services_project = project.id
                         break
                 

--- a/hamgr/hamgr/providers/cinder.py
+++ b/hamgr/hamgr/providers/cinder.py
@@ -146,24 +146,22 @@ class CinderProvider(Provider):
             LOG.exception(f"Error finding other hosts with backend {backend_name}: {str(e)}")
             return []
 
-    def _get_volumes_for_migration(self, cinder_host, backend_name):
+    def _get_volumes_for_migration(self, cinder_host):
         try:
             client = self._get_cinder_client()
             
-            host_filters = [
-                f"{cinder_host}@{backend_name}",
-                f"{cinder_host}@{backend_name}#{backend_name}",
-                f"{cinder_host}#{backend_name}"
-            ]
+            search_opts = {'all_tenants': True}
+            all_volumes = client.volumes.list(detailed=True, search_opts=search_opts)
             
-            all_volumes = []
-            for host_filter in host_filters:
-                search_opts = {'host': host_filter, 'all_tenants': True}
-                LOG.debug(f"Searching for volumes with options: {search_opts}")
-                volumes = client.volumes.list(detailed=True, search_opts=search_opts)
-                if volumes:
-                    LOG.info(f"Found {len(volumes)} volumes with host filter: {host_filter}")
-                    all_volumes.extend(volumes)
+            # Filter volumes that match our cinder_host
+            host_volumes = []
+            for vol in all_volumes:
+                if hasattr(vol, 'os-vol-host-attr:host') and cinder_host in vol._info['os-vol-host-attr:host']:
+                    host_volumes.append(vol)
+                    LOG.debug(f"Found volume {vol.id} on host {vol._info['os-vol-host-attr:host']}")
+            
+            LOG.debug(f"Found {len(host_volumes)} volumes on host {cinder_host}")
+            all_volumes = host_volumes
             
             unique_volumes = {}
             for vol in all_volumes:
@@ -192,27 +190,28 @@ class CinderProvider(Provider):
                         break
                 
                 if services_project:
-                    for host_filter in host_filters:
-                        service_opts = {
-                            'host': host_filter, 
-                            'all_tenants': True,
-                            'project_id': services_project
-                        }
-                        LOG.debug(f"Searching for glance volumes in services project: {service_opts}")
-                        service_volumes = client.volumes.list(detailed=True, search_opts=service_opts)
-                        
-                        existing_ids = [v.id for v in all_volumes]
-                        for vol in service_volumes:
-                            if vol.id not in existing_ids:
-                                all_volumes.append(vol)
-                                LOG.info(f"Found glance volume: {vol.id} in services project")
+                    # Get all volumes in the services project
+                    service_opts = {
+                        'all_tenants': True,
+                        'project_id': services_project
+                    }
+                    LOG.debug(f"Searching for glance volumes in services project: {service_opts}")
+                    service_volumes = client.volumes.list(detailed=True, search_opts=service_opts)
+                    
+                    # Filter volumes that match our cinder_host
+                    existing_ids = [v.id for v in all_volumes]
+                    for vol in service_volumes:
+                        if (hasattr(vol, 'os-vol-host-attr:host') and 
+                            cinder_host in vol._info['os-vol-host-attr:host'] and 
+                            vol.id not in existing_ids):
+                            all_volumes.append(vol)
+                            LOG.info(f"Found glance volume: {vol.id} on host {vol._info['os-vol-host-attr:host']} in services project")
             except Exception as e:
                 LOG.exception(f"Error searching for volumes in services project: {str(e)}")
             
-            LOG.info(f"Found total of {len(all_volumes)} volumes on host {cinder_host} with backend {backend_name}")
             return all_volumes
         except Exception as e:
-            LOG.exception(f"Error getting volumes on host {cinder_host} with backend {backend_name}: {str(e)}")
+            LOG.exception(f"Error getting volumes on host {cinder_host}: {str(e)}")
             return []
 
     def _get_backend_pools(self):
@@ -231,11 +230,10 @@ class CinderProvider(Provider):
         
         # Find pools that match both the backend name and configuration
         # Format is typically: <uuid>@<backend_config>#<backend_name>
-        matching_pools = [pool for pool in pool_names 
-                         if '#' in pool and '@' in pool 
-                         and pool.split('#')[1] == backend_name 
-                         and pool.split('@')[1].split('#')[0] == backend_config 
-                         and pool != f"{backend_config}#{backend_name}"]
+        matching_pools = [pool for pool in pool_names
+                         if '#' in pool and '@' in pool
+                         and pool.split('#')[1] == backend_config
+                         and pool.split('@')[1].split('#')[0] == backend_name]
         
         LOG.info(f"Found {len(matching_pools)} pools with backend '{backend_name}' and config '{backend_config}'")
         
@@ -252,7 +250,7 @@ class CinderProvider(Provider):
         try:
             LOG.info(f"Migrating volumes from {cinder_host}@{backend_name} to {new_host}@{backend_name}")
             
-            volumes = self._get_volumes_for_migration(cinder_host, backend_name)
+            volumes = self._get_volumes_for_migration(cinder_host)
             if not volumes:
                 LOG.info(f"No volumes found to migrate from {cinder_host}@{backend_name}")
                 return True
@@ -274,7 +272,7 @@ class CinderProvider(Provider):
             
             # Extract the backend configuration from the source host format
             if '@' in source_host_format and '#' in source_host_format:
-                source_config = source_host_format.split('@')[1].split('#')[0]
+                source_config = source_host_format.split('@')[1].split('#')[1]
                 LOG.info(f"Extracted backend configuration '{source_config}' from source host format")
             else:
                 LOG.error(f"Could not extract backend configuration from source host format: {source_host_format}")
@@ -532,7 +530,7 @@ class CinderProvider(Provider):
                         LOG.info(f"Found {len(other_hosts)} other hosts with backend {backend_name}: {', '.join(other_hosts)}")
                         
                         # Get volumes across all projects for cross-AZ attachments and glance backend
-                        volumes = self._get_volumes_for_migration(host_name, backend_name)
+                        volumes = self._get_volumes_for_migration(host_name)
                         if not volumes:
                             LOG.info(f"No volumes found on {host_name}@{backend_name}, skipping migration for this backend")
                             continue


### PR DESCRIPTION
This change fixes the filter for volumes. The previous change was not considering the backend config name correctly and was not able to find volumes in that host because of it. With this change, I'm simplifying the check by ignoring the backend name and backend config and finding all volumes that match just the host ID.

Testing:
Before migration -

Available pools:
```
bash-3.2$ openstack volume backend pool list
+---------------------------------------------------+
| Name                                              |
+---------------------------------------------------+
| 5651926f-15bc-4988-b49c-1dbd8e6976a2@nfs-1#vt-nfs |
| 0d58b7af-eb68-4ceb-8d3c-910cc80957a2@nfs-1#vt-nfs |
| e402ba07-3295-444c-b802-5d4a5bbaeab3@nfs-1#vt-nfs |
| f3ebcc2d-8677-43aa-933b-c9810407719f@nfs-1#vt-nfs |
+---------------------------------------------------+
```

Volumes, and the hosts attached to it (of the format <volume-id>:<pool-name>):
```
bash-3.2$ for id in $(openstack volume list -c ID -f value); do echo -n "$id: "; openstack volume show $id -c os-vol-host-attr:host -f value; done
ac08f368-e54b-4c6f-89c2-e7e899c9519b: 0d58b7af-eb68-4ceb-8d3c-910cc80957a2@nfs-1#vt-nfs
7cf9f52b-b63d-407a-86eb-73680a823206: f3ebcc2d-8677-43aa-933b-c9810407719f@nfs-1#vt-nfs
24932e93-153f-4723-9a4f-c31c34e58ae4: f3ebcc2d-8677-43aa-933b-c9810407719f@nfs-1#vt-nfs
```

Bringing down host `f3ebcc2d-8677-43aa-933b-c9810407719f`. Available pools now:
```
bash-3.2$ openstack volume backend pool list
+---------------------------------------------------+
| Name                                              |
+---------------------------------------------------+
| 5651926f-15bc-4988-b49c-1dbd8e6976a2@nfs-1#vt-nfs |
| 0d58b7af-eb68-4ceb-8d3c-910cc80957a2@nfs-1#vt-nfs |
| e402ba07-3295-444c-b802-5d4a5bbaeab3@nfs-1#vt-nfs |
+---------------------------------------------------+
```

 Hamgr logs identifies the host down event and migrates the 2 volumes on the host:
```
025-04-06 23:31:27,572 vmha.hamgr.providers.cinder INFO Detected standalone cinder host down: f3ebcc2d-8677-43aa-933b-c9810407719f@nfs-1
2025-04-06 23:31:27,573 vmha.hamgr.providers.cinder INFO Creating new cinder host down event with UUID c0885726-0ef4-4d59-aaef-76f9dce82d3a for host f3ebcc2d-8677-43aa-933b-c9810407719f@nfs-1
2025-04-06 23:31:28,070 vmha.hamgr.providers.cinder INFO Detected standalone cinder host down: 5998a634-c380-4e39-9d65-ce183ee7e8a3@nfs-1
2025-04-06 23:31:28,087 vmha.hamgr.providers.cinder INFO Creating new cinder host down event with UUID 827068ce-684c-4f34-bafc-232c46de043d for host 5998a634-c380-4e39-9d65-ce183ee7e8a3@nfs-1
2025-04-06 23:31:29,602 vmha.hamgr.providers.cinder INFO Found 2 cinder host events to process: Event[uuid=c0885726-0ef4-4d59-aaef-76f9dce82d3a, type=host-down, host=f3ebcc2d-8677-43aa-933b-c9810407719f@nfs-1, time=2025-04-06 23:31:28, status=], Event[uuid=827068ce-684c-4f34-bafc-232c46de043d, type=host-down, host=5998a634-c380-4e39-9d65-ce183ee7e8a3@nfs-1, time=2025-04-06 23:31:28, status=]
2025-04-06 23:31:30,097 vmha.hamgr.providers.cinder INFO Processing cinder host down event for f3ebcc2d-8677-43aa-933b-c9810407719f@nfs-1
2025-04-06 23:31:30,560 vmha.hamgr.providers.cinder INFO Found 1 backends for host f3ebcc2d-8677-43aa-933b-c9810407719f@nfs-1: nfs-1
2025-04-06 23:31:31,028 vmha.hamgr.providers.cinder INFO Cinder host f3ebcc2d-8677-43aa-933b-c9810407719f@nfs-1 is part of availability zones: nova
2025-04-06 23:31:31,044 vmha.hamgr.providers.cinder INFO Processing backend nfs-1 on host f3ebcc2d-8677-43aa-933b-c9810407719f@nfs-1
2025-04-06 23:31:31,509 vmha.hamgr.providers.cinder INFO Found 3 other hosts with backend nfs-1: 5651926f-15bc-4988-b49c-1dbd8e6976a2@nfs-1, 0d58b7af-eb68-4ceb-8d3c-910cc80957a2@nfs-1, e402ba07-3295-444c-b802-5d4a5bbaeab3@nfs-1
2025-04-06 23:31:32,515 vmha.hamgr.providers.cinder INFO Found 2 volumes on f3ebcc2d-8677-43aa-933b-c9810407719f@nfs-1@nfs-1 to migrate: 7cf9f52b-b63d-407a-86eb-73680a823206, 24932e93-153f-4723-9a4f-c31c34e58ae4
2025-04-06 23:31:32,526 vmha.hamgr.providers.cinder INFO Selected host 5651926f-15bc-4988-b49c-1dbd8e6976a2@nfs-1 as migration target for volumes from f3ebcc2d-8677-43aa-933b-c9810407719f@nfs-1@nfs-1
2025-04-06 23:31:32,531 vmha.hamgr.providers.cinder INFO Migrating volumes from f3ebcc2d-8677-43aa-933b-c9810407719f@nfs-1@nfs-1 to 5651926f-15bc-4988-b49c-1dbd8e6976a2@nfs-1@nfs-1
2025-04-06 23:31:33,494 vmha.hamgr.providers.cinder INFO Found 2 volumes to migrate: 7cf9f52b-b63d-407a-86eb-73680a823206, 24932e93-153f-4723-9a4f-c31c34e58ae4
2025-04-06 23:31:33,505 vmha.hamgr.providers.cinder INFO Detected original volume host format: f3ebcc2d-8677-43aa-933b-c9810407719f@nfs-1#vt-nfs
2025-04-06 23:31:33,972 vmha.hamgr.providers.cinder INFO Found 3 backend pools: 5651926f-15bc-4988-b49c-1dbd8e6976a2@nfs-1#vt-nfs, 0d58b7af-eb68-4ceb-8d3c-910cc80957a2@nfs-1#vt-nfs, e402ba07-3295-444c-b802-5d4a5bbaeab3@nfs-1#vt-nfs
2025-04-06 23:31:33,987 vmha.hamgr.providers.cinder INFO Extracted backend configuration 'vt-nfs' from source host format
2025-04-06 23:31:33,992 vmha.hamgr.providers.cinder INFO Looking for pools with backend 'nfs-1' and config 'vt-nfs'
2025-04-06 23:31:33,998 vmha.hamgr.providers.cinder INFO Found 3 pools with backend 'nfs-1' and config 'vt-nfs'
2025-04-06 23:31:34,008 vmha.hamgr.providers.cinder INFO Selected migration target pool: 5651926f-15bc-4988-b49c-1dbd8e6976a2@nfs-1#vt-nfs from 3 available pools
2025-04-06 23:31:34,008 vmha.hamgr.providers.cinder INFO Migrating from f3ebcc2d-8677-43aa-933b-c9810407719f@nfs-1#vt-nfs to 5651926f-15bc-4988-b49c-1dbd8e6976a2@nfs-1#vt-nfs
2025-04-06 23:31:34,008 vmha.hamgr.providers.cinder INFO Using cinder-manage to migrate volumes to 5651926f-15bc-4988-b49c-1dbd8e6976a2@nfs-1#vt-nfs
2025-04-06 23:31:34,014 vmha.hamgr.providers.cinder INFO Created cinder.conf at /etc/pf9/cinder.conf
2025-04-06 23:31:34,025 vmha.hamgr.providers.cinder INFO Executing command: cinder-manage --config-file /etc/pf9/cinder.conf volume update_host --currenthost f3ebcc2d-8677-43aa-933b-c9810407719f@nfs-1#vt-nfs --newhost 5651926f-15bc-4988-b49c-1dbd8e6976a2@nfs-1#vt-nfs
2025-04-06 23:31:38,148 vmha.hamgr.providers.cinder INFO Database update for migration from f3ebcc2d-8677-43aa-933b-c9810407719f@nfs-1#vt-nfs to 5651926f-15bc-4988-b49c-1dbd8e6976a2@nfs-1#vt-nfs completed
2025-04-06 23:31:40,563 vmha.hamgr.providers.cinder INFO Checking volume 7cf9f52b-b63d-407a-86eb-73680a823206 migration: current host = 5651926f-15bc-4988-b49c-1dbd8e6976a2@nfs-1#vt-nfs, target = 5651926f-15bc-4988-b49c-1dbd8e6976a2@nfs-1#vt-nfs
2025-04-06 23:31:40,563 vmha.hamgr.providers.cinder INFO Volume 7cf9f52b-b63d-407a-86eb-73680a823206 successfully migrated to 5651926f-15bc-4988-b49c-1dbd8e6976a2@nfs-1#vt-nfs
2025-04-06 23:31:40,599 vmha.hamgr.providers.cinder INFO Checking volume 24932e93-153f-4723-9a4f-c31c34e58ae4 migration: current host = 5651926f-15bc-4988-b49c-1dbd8e6976a2@nfs-1#vt-nfs, target = 5651926f-15bc-4988-b49c-1dbd8e6976a2@nfs-1#vt-nfs
2025-04-06 23:31:40,599 vmha.hamgr.providers.cinder INFO Volume 24932e93-153f-4723-9a4f-c31c34e58ae4 successfully migrated to 5651926f-15bc-4988-b49c-1dbd8e6976a2@nfs-1#vt-nfs
2025-04-06 23:31:40,599 vmha.hamgr.providers.cinder INFO Successfully verified migration from f3ebcc2d-8677-43aa-933b-c9810407719f@nfs-1#vt-nfs to 5651926f-15bc-4988-b49c-1dbd8e6976a2@nfs-1#vt-nfs
2025-04-06 23:31:40,599 vmha.hamgr.providers.cinder INFO Successfully processed all backends for host f3ebcc2d-8677-43aa-933b-c9810407719f@nfs-1, marking event c0885726-0ef4-4d59-aaef-76f9dce82d3a as finished
```

Pool IDs for the volumes post migration:
```
bash-3.2$ for id in $(openstack volume list -c ID -f value); do echo -n "$id: "; openstack volume show $id -c os-vol-host-attr:host -f value; done
ac08f368-e54b-4c6f-89c2-e7e899c9519b: 0d58b7af-eb68-4ceb-8d3c-910cc80957a2@nfs-1#vt-nfs
7cf9f52b-b63d-407a-86eb-73680a823206: 5651926f-15bc-4988-b49c-1dbd8e6976a2@nfs-1#vt-nfs
24932e93-153f-4723-9a4f-c31c34e58ae4: 5651926f-15bc-4988-b49c-1dbd8e6976a2@nfs-1#vt-nfs
``` 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request addresses issues with volume filtering during host-down events by simplifying the logic for retrieving volumes. The changes remove the backend parameter from the migration function and use a more straightforward filtering mechanism based solely on the host. Additionally, the pool matching logic and source configuration extraction have been refined to ensure accurate volume selection.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>