### PR TITLE
use internal endpoint for cinder client

### DIFF
--- a/hamgr/hamgr/providers/cinder.py
+++ b/hamgr/hamgr/providers/cinder.py
@@ -78,7 +78,7 @@ class CinderProvider(Provider):
             project_domain_id='default'
         )
         sess = session.Session(auth=auth)
-        return cinder_client.Client('3', session=sess, region_name=self._region)
+        return cinder_client.Client('3', session=sess, region_name=self._region, interface='internal')
 
     def _get_cinder_hosts(self):
         cinder_hosts = []


### PR DESCRIPTION
to avoid errors in on-prem
keystoneauth1.exceptions.connection.ConnectFailure: Unable to establish connection to https://airctl-1-3683243-469-mel.platform9.localnet/cinder/v3/58cd1c811099462f8ba30d05ab2c3689/os-services?binary=cinder-volume: HTTPSConnectionPool(host='airctl-1-3683243-469-mel.platform9.localnet', port=443): Max retries exceeded with url: /cinder/v3/58cd1c811099462f8ba30d05ab2c3689/os-services?binary=cinder-volume (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x7fdc2d846370>: Failed to establish a new connection: [Errno -2] Name does not resolve')) 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR updates the cinder client initialization to include the 'internal' interface parameter, directing the client to an internal endpoint. This change addresses connection failures in on-prem configurations by preventing DNS resolution issues and connection errors in hamgr/hamgr/providers/cinder.py.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>