### PR TITLE
Fix VMHA case where inter-host connectivity in 2 node case is down

### DIFF
--- a/hamgr/hamgr/wsgi.py
+++ b/hamgr/hamgr/wsgi.py
@@ -428,7 +428,7 @@ def host_status_handler(host_id):
         if len(VMHA_TABLE[host]) >= 5:
             VMHA_TABLE[host].pop(0)
         LOG.debug(f"Cache looks like {VMHA_CACHE}. Table looks like this {VMHA_TABLE}")
-        if VMHA_TABLE[host].count(True)-VMHA_TABLE[host].count(False) < 0:
+        if VMHA_TABLE[host].count(True)-VMHA_TABLE[host].count(False) <= 0:
             if host in VMHA_CACHE:
                 if time.time() - VMHA_CACHE[host] > MAX_FAILED_TIME and VMHA_CACHE[host]!=0:
                     LOG.info(f"Triggering migration of VMs on host {host} after being failed for {time.time() - VMHA_CACHE[host]} seconds")


### PR DESCRIPTION
# JIRA
https://platform9.atlassian.net/browse/PCD-2358

# What's done here
Handling edge case for 2 node VMHA setup with host being up but interhost-connectivity is down. In this case we see the table entry as [True, False, True, False]. So the updated condition will handle this case 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request fixes a critical bug in the VMHA module by changing the VM migration trigger condition from '<' to '<=' for handling equal True/False counts. The modification improves system responsiveness to edge cases in 2-node VMHA setups and ensures better handling of inter-host connectivity issues.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>