### PR TITLE
Increase cooldown to 180sec for hamgr

### DIFF
--- a/hamgr/hamgr/wsgi.py
+++ b/hamgr/hamgr/wsgi.py
@@ -32,7 +32,7 @@ CONTENT_TYPE_HEADER = {'Content-Type': 'application/json'}
 
 VMHA_CACHE = {}
 VMHA_TABLE={}
-MAX_FAILED_TIME = 10
+MAX_FAILED_TIME = 180
 # ^ in sec
 
 class MockEvent:


### PR DESCRIPTION
<div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR extends the VMHA component cooldown period in the hamgr module by increasing MAX_FAILED_TIME from 10 to 180 seconds. The change improves system stability by implementing a longer waiting period after failed attempts, targeting better handling of repeated failures.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>