### PR TITLE
Re-enable vmha status on a cluster if it fails to apply vmha role and resmgr has vmha enabled

### DIFF
--- a/hamgr/hamgr/db/api.py
+++ b/hamgr/hamgr/db/api.py
@@ -58,6 +58,9 @@ class Cluster(Base):
     name = Column(String(255))
     task_state = Column(String(36), nullable=True)
 
+    def __repr__(self):
+        return f"<Cluster name: {self.name}, id: {self.id}, status: {self.status}, enabled: {self.enabled}, task_state: {self.task_state}>"
+
 
 class ChangeEvents(Base):
     __tablename__ = 'change_events'

--- a/hamgr/hamgr/providers/nova.py
+++ b/hamgr/hamgr/providers/nova.py
@@ -568,7 +568,11 @@ class NovaProvider(Provider):
                          current_cluster.name, az_name)
                 if current_cluster.status == 'request-enable': 
                    LOG.info('VMHA is not yet enabled for availability zone: %s not precessing it', current_cluster.name)                                 
-                   continue  
+                   continue
+                if self.check_vmha_enabled_on_resmgr(current_cluster):
+                    LOG.info('VMHA enabled on cluster %s from resmgr. Setting db state to request-enable', current_cluster.name)
+                    db_api.update_request_status(current_cluster.name, constants.HA_STATE_REQUEST_ENABLE)
+                    continue
                 # reconcile hosts to hamgr and masakari
                 cluster_name = current_cluster.name
                 cluster_enabled = current_cluster.enabled
@@ -610,8 +614,8 @@ class NovaProvider(Provider):
                             self._remove_ha_slave_if_exist(cluster_name, masakari_delta_ids, common_ids)
                             LOG.info('try to rebalance consul roles after removed hosts : %s',
                                      str(masakari_delta_ids))
-                            time.sleep(30)
-                            self._rebalance_consul_roles_if_needed(cluster_name, constants.EVENT_HOST_REMOVED)
+                            #time.sleep(30)
+                            #self._rebalance_consul_roles_if_needed(cluster_name, constants.EVENT_HOST_REMOVED)
 
                 masakari_hosts = []
 

--- a/hamgr/hamgr/providers/nova.py
+++ b/hamgr/hamgr/providers/nova.py
@@ -569,7 +569,7 @@ class NovaProvider(Provider):
                 if current_cluster.status == 'request-enable': 
                    LOG.info('VMHA is not yet enabled for availability zone: %s not precessing it', current_cluster.name)                                 
                    continue
-                if self.check_vmha_enabled_on_resmgr(current_cluster):
+                if self.check_vmha_enabled_on_resmgr(current_cluster.name):
                     LOG.info('VMHA enabled on cluster %s from resmgr. Setting db state to request-enable', current_cluster.name)
                     db_api.update_request_status(current_cluster.name, constants.HA_STATE_REQUEST_ENABLE)
                     continue

--- a/hamgr/hamgr/providers/nova.py
+++ b/hamgr/hamgr/providers/nova.py
@@ -575,6 +575,7 @@ class NovaProvider(Provider):
                     if hamgr_entry.status in [constants.HA_STATE_DISABLED]:
                         LOG.info('VMHA enabled on cluster %s from resmgr. Setting db state to request-enable', current_cluster.name)
                         db_api.update_request_status(current_cluster.name, constants.HA_STATE_REQUEST_ENABLE)
+                        db_api.update_cluster_task_state(current_cluster.name, constants.TASK_WAITING)
                         continue
                 # reconcile hosts to hamgr and masakari
                 cluster_name = current_cluster.name

--- a/hamgr/hamgr/providers/nova.py
+++ b/hamgr/hamgr/providers/nova.py
@@ -570,9 +570,12 @@ class NovaProvider(Provider):
                    LOG.info('VMHA is not yet enabled for availability zone: %s not precessing it', current_cluster.name)                                 
                    continue
                 if self.check_vmha_enabled_on_resmgr(current_cluster.name):
-                    LOG.info('VMHA enabled on cluster %s from resmgr. Setting db state to request-enable', current_cluster.name)
-                    db_api.update_request_status(current_cluster.name, constants.HA_STATE_REQUEST_ENABLE)
-                    continue
+                    hamgr_entry = db_api.get_cluster(current_cluster.name)
+                    LOG.debug("current cluster status in hamgr %s", hamgr_entry.status)
+                    if hamgr_entry.status in [constants.HA_STATE_DISABLED]:
+                        LOG.info('VMHA enabled on cluster %s from resmgr. Setting db state to request-enable', current_cluster.name)
+                        db_api.update_request_status(current_cluster.name, constants.HA_STATE_REQUEST_ENABLE)
+                        continue
                 # reconcile hosts to hamgr and masakari
                 cluster_name = current_cluster.name
                 cluster_enabled = current_cluster.enabled


### PR DESCRIPTION
# JIRA
https://platform9.atlassian.net/browse/PCD-2491
# Testing
```
2025-06-12 10:34:01,812 vmha.hamgr.providers.nova INFO pick the first matched vmha cluster navin for availability zone name navin
2025-06-12 10:34:01,879 vmha.hamgr.providers.nova DEBUG response from resmgr {'name': 'navin', 'description': '', 'vmHighAvailability': {'enabled': True}, 'autoResourceRebalancing': 
{'enabled': False, 'rebalancingFrequencyMins': 10}, 'gpu': {'enabled': False, 'mode': 'passthrough'}, 'hostlist': ['04d21243-7633-49c8-af3c-d32184950b66', '5e4e6064-60d9-4e45-ad02-28
da16724061'], 'aggregate_id': 1, 'created_at': '2025-06-12T06:37:47', 'updated_at': '2025-06-12T06:37:47'}
2025-06-12 10:34:01,880 vmha.hamgr.providers.nova INFO VMHA enabled on cluster navin from resmgr. Setting db state to request-enable
```
DB state before
```
MySQL [resmgr]> select * from hamgr.clusters;
+----+---------+-------+---------+---------+---------------------+---------------------+------------+------------+
| id | deleted | name  | enabled | status  | updated_at          | created_at          | deleted_at | task_state |
+----+---------+-------+---------+---------+---------------------+---------------------+------------+------------+
|  1 |       0 | navin |       0 | disable | 2025-06-12 09:56:42 | 2025-06-12 09:56:42 | NULL       | waiting    |
+----+---------+-------+---------+---------+---------------------+---------------------+------------+------------+
```
DB state after
```
+----+---------+-------+---------+---------+---------------------+---------------------+------------+------------+
| id | deleted | name  | enabled | status  | updated_at          | created_at          | deleted_at | task_state |
+----+---------+-------+---------+---------+---------------------+---------------------+------------+------------+
|  1 |       0 | navin |       1 | enabled | 2025-06-12 10:34:12 | 2025-06-12 09:56:42 | NULL       | NULL       |
+----+---------+-------+---------+---------+---------------------+---------------------+------------+------------+
```
pf9-ha-slave role gets pushed to hosts 

# [UPDATE]
Fixed the looping condition where the cluster nodes were getting ha-role pushed continuously just because the resmgr table had vmha enabled. 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR improves Cluster object representation and fixes VMHA status handling in the nova provider where incorrect management caused repetitive ha-role pushes. The solution retrieves current cluster state from the database, ensures clusters accurately reflect VMHA status based on real-time data checks, and only updates request status when the cluster is disabled, preventing erroneous loops, unnecessary delay, rebalance operations, and database inconsistencies.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>