### PR TITLE
Fix liveness probe and reduce failure points in hamgr

### DIFF
--- a/hamgr/container/liveness_probe.py
+++ b/hamgr/container/liveness_probe.py
@@ -49,6 +49,6 @@ if __name__ == "__main__":
         #    result = subprocess.run(['supervisorctl', 'restart', 'hamgr'], capture_output=True, text=True)
         #    logger.info(result.stdout)
     else: 
-        logger.error(f"Failed to connect hamgr")
+        logger.error(f"Failed to connect hamgr. Response code {response.status_code}")
         sys.exit(1)
     sys.exit(0)

--- a/hamgr/container/liveness_probe.py
+++ b/hamgr/container/liveness_probe.py
@@ -39,9 +39,9 @@ if __name__ == "__main__":
     catalog = auth_ref.service_catalog.get_endpoints(service_type='hamgr', interface='internal',region_name=config.get('DEFAULT', 'region_name'), service_name='hamgr' )
     hamgr_endpoint = catalog['hamgr'][0]['url']
     token = sess.get_token()
-    HAMGR_URL = hamgr_endpoint + 'v1/ha'
+    HAMGR_URL = hamgr_endpoint + '/version'
     headers = {"X-AUTH-TOKEN": token}
-    response = requests.get(HAMGR_URL, headers=headers)
+    response = requests.get(HAMGR_URL, headers=headers,timeout=60)
     data = response.json()
     if response.status_code == 200:
         if data["status"] == None:

--- a/hamgr/container/liveness_probe.py
+++ b/hamgr/container/liveness_probe.py
@@ -44,9 +44,10 @@ if __name__ == "__main__":
     response = requests.get(HAMGR_URL, headers=headers,timeout=60)
     data = response.json()
     if response.status_code == 200:
-        if data["status"] == None:
-            result = subprocess.run(['supervisorctl', 'restart', 'hamgr'], capture_output=True, text=True)
-            logger.info(result.stdout)
+        logger.info("response received")
+        #if data["status"] == None:
+        #    result = subprocess.run(['supervisorctl', 'restart', 'hamgr'], capture_output=True, text=True)
+        #    logger.info(result.stdout)
     else: 
         logger.error(f"Failed to connect hamgr")
         sys.exit(1)

--- a/hamgr/hamgr/providers/nova.py
+++ b/hamgr/hamgr/providers/nova.py
@@ -3076,7 +3076,7 @@ class NovaProvider(Provider):
         # if n is less than r, we can't make combinations
         if len(host_ids) - 1 > VMHA_MAX_FANOUT:
             picking_list = ip_map.keys()
-            list_len = len(picking_list)
+            list_len = len(picking_list)-1
             ind1, ind2, ind3 = randint(0, list_len), randint(0, list_len), randint(0, list_len)
             final_map={
                 picking_list[ind1]: ip_map[picking_list[ind1]],

--- a/hamgr/hamgr/providers/nova.py
+++ b/hamgr/hamgr/providers/nova.py
@@ -3076,7 +3076,7 @@ class NovaProvider(Provider):
         # Make nCr type combinations and choose amongst them randomly
         # if n is less than r, we can't make combinations
         if len(host_ids) - 1 > VMHA_MAX_FANOUT:
-            picking_list = ip_map.keys()
+            picking_list = list(ip_map.keys())
             list_len = len(picking_list)-1
             ind1, ind2, ind3 = randint(0, list_len), randint(0, list_len), randint(0, list_len)
             final_map={

--- a/hamgr/hamgr/providers/nova.py
+++ b/hamgr/hamgr/providers/nova.py
@@ -161,8 +161,8 @@ class NovaProvider(Provider):
         self.queue_processing_running = False
         
         # vmha caching of nova output
-        self.host_with_same_cluster={"host_ids":[], "last_check":0}
-        self.host_ip_to_id_map={}
+        self.vmha_os_aggregates={"last_check":0, "response":{}}
+        self.vmha_nova_details={"last_check":0, "response":{}}
 
     def _get_v3_token(self):
         self._token = utils.get_token(self._auth_url,
@@ -3014,25 +3014,26 @@ class NovaProvider(Provider):
         
     # Get host-ids within same cluster as a host
     def get_hosts_with_same_cluster(self, host_id):
-        if time.time() - self.host_with_same_cluster["last_check"] < VMHA_HOST_CACHE_INVALIDATION:
-            for host_list in self.host_with_same_cluster["host_ids"]:
-                if host_id in host_list:
-                    LOG.info("Cache hit for host list")
-                    return host_list
-        LOG.info("cache miss. Adding to cache %s", host_id)
-        self.host_with_same_cluster["last_check"] = time.time()
         host_ids = []
         headers = {"X-AUTH-TOKEN": self._token['id']}
         url = 'http://nova-api.' + self._du_name + '.svc.cluster.local:8774/v2.1/os-aggregates'
-        try:
-            LOG.debug("request sent to %s", url)
-            response = requests.get(url, headers=headers,timeout=NOVA_REQ_TIMEOUT)
-        except requests.exceptions.Timeout:
-            LOG.debug("request timed out %s", url)
-            return host_ids
-        LOG.debug("request completed to %s", url)
+        flag=False
+        if time.time() - self.vmha_os_aggregates["last_check"] > VMHA_HOST_CACHE_INVALIDATION or self.vmha_os_aggregates["response"]=={}:
+            flag=True
+            try:
+                LOG.debug("request sent to %s", url)
+                response = requests.get(url, headers=headers,timeout=NOVA_REQ_TIMEOUT)
+            except requests.exceptions.Timeout:
+                LOG.debug("request timed out %s", url)
+                return host_ids
+            LOG.debug("request completed to %s", url)
         if response.status_code == 200:
-            data = response.json()
+            if flag:
+                data = response.json()
+                self.vmha_os_aggregates["last_check"] = time.time()
+                self.vmha_os_aggregates["response"]=data
+            else:
+                data=self.vmha_os_aggregates["response"]
             if 'aggregates' in data:
                 filtered_aggregates = list(filter(lambda x: x["availability_zone"]!=None and host_id in x["hosts"], data['aggregates']))
                 host_ids = filtered_aggregates[0]['hosts'] if filtered_aggregates else []
@@ -3044,21 +3045,26 @@ class NovaProvider(Provider):
         if host_id in self.host_ip_to_id_map:
             return self.host_ip_to_id_map[host_id]
         ip=""
-        if self._hypervisor_details == "":
-            headers = {"X-AUTH-TOKEN": self._token['id']}
-            # We dont know whats the hypervisor id so be brute force it
-            url = 'http://nova-api.' + self._du_name + '.svc.cluster.local:8774/v2.1/os-hypervisors/detail'
+        headers = {"X-AUTH-TOKEN": self._token['id']}
+        # We dont know whats the hypervisor id so be brute force it
+        url = 'http://nova-api.' + self._du_name + '.svc.cluster.local:8774/v2.1/os-hypervisors/detail'
+        flag=False
+        if time.time() - self.vmha_nova_details["last_check"] > VMHA_HOST_CACHE_INVALIDATION or self.vmha_nova_details["response"]=={}:
+            flag=True
             try:
                 LOG.debug("request sent to %s", url)
                 response = requests.get(url, headers=headers, timeout=NOVA_REQ_TIMEOUT)
             except requests.exceptions.Timeout:
                 LOG.debug("request timed out %s", url)
                 return ip
-            LOG.debug("request completed to %s", url)
-            if response.status_code == 200:
+        LOG.debug("request completed to %s", url)
+        if response.status_code == 200:
+            if flag:
                 data = response.json()
-        else:
-            data = self._hypervisor_details
+                self.vmha_nova_details["last_check"] = time.time()
+                self.vmha_nova_details["response"]=data
+            else:
+                data=self.vmha_nova_details["response"]
         if 'hypervisors' in data:
             if len(data['hypervisors']) > 0:
                 ip = list(filter(lambda x:x['service']['host'] == host_id, data['hypervisors']))[0]['host_ip']
@@ -3084,6 +3090,7 @@ class NovaProvider(Provider):
 
         # Make nCr type combinations and choose amongst them randomly
         # if n is less than r, we can't make combinations
+        LOG.debug("starting combinations")
         if len(host_ids) - 1 > VMHA_MAX_FANOUT:
             picking_list = list(ip_map.keys())
             list_len = len(picking_list)-1

--- a/hamgr/hamgr/providers/nova.py
+++ b/hamgr/hamgr/providers/nova.py
@@ -3019,6 +3019,7 @@ class NovaProvider(Provider):
         url = 'http://nova-api.' + self._du_name + '.svc.cluster.local:8774/v2.1/os-aggregates'
         flag=False
         if time.time() - self.vmha_os_aggregates["last_check"] > VMHA_HOST_CACHE_INVALIDATION or self.vmha_os_aggregates["response"]=={}:
+            LOG.debug("internal %s cache looks like %s", time.time(), self.vmha_os_aggregates)
             flag=True
             try:
                 LOG.debug("request sent to %s", url)
@@ -3026,7 +3027,7 @@ class NovaProvider(Provider):
             except requests.exceptions.Timeout:
                 LOG.debug("request timed out %s", url)
                 return host_ids
-            LOG.debug("request completed to %s", url)
+            LOG.debug("request completed with response %s", response.status_code)
         if flag:
             if response.status_code == 200:
                 data = response.json()
@@ -3049,6 +3050,7 @@ class NovaProvider(Provider):
         url = 'http://nova-api.' + self._du_name + '.svc.cluster.local:8774/v2.1/os-hypervisors/detail'
         flag=False
         if time.time() - self.vmha_nova_details["last_check"] > VMHA_HOST_CACHE_INVALIDATION or self.vmha_nova_details["response"]=={}:
+            LOG.debug("internal %s cache looks like %s", time.time(), self.vmha_nova_details)
             flag=True
             try:
                 LOG.debug("request sent to %s", url)
@@ -3056,7 +3058,7 @@ class NovaProvider(Provider):
             except requests.exceptions.Timeout:
                 LOG.debug("request timed out %s", url)
                 return ip
-        LOG.debug("request completed to %s", url)
+            LOG.debug("request completed with response %s", response.status_code)
         if flag:
             if response.status_code == 200:
                 data = response.json()

--- a/hamgr/hamgr/providers/nova.py
+++ b/hamgr/hamgr/providers/nova.py
@@ -3025,8 +3025,10 @@ class NovaProvider(Provider):
         headers = {"X-AUTH-TOKEN": self._token['id']}
         url = 'http://nova-api.' + self._du_name + '.svc.cluster.local:8774/v2.1/os-aggregates'
         try:
+            LOG.debug("request sent to %s", url)
             response = requests.get(url, headers=headers,timeout=NOVA_REQ_TIMEOUT)
         except requests.exceptions.Timeout:
+            LOG.debug("request timed out %s", url)
             return host_ids
         if response.status_code == 200:
             data = response.json()
@@ -3046,8 +3048,10 @@ class NovaProvider(Provider):
             # We dont know whats the hypervisor id so be brute force it
             url = 'http://nova-api.' + self._du_name + '.svc.cluster.local:8774/v2.1/os-hypervisors/detail'
             try:
+                LOG.debug("request sent to %s", url)
                 response = requests.get(url, headers=headers, timeout=NOVA_REQ_TIMEOUT)
             except requests.exceptions.Timeout:
+                LOG.debug("request timed out %s", url)
                 return ip
             if response.status_code == 200:
                 data = response.json()
@@ -3064,6 +3068,7 @@ class NovaProvider(Provider):
         LOG.info("handling request for host_id %s", host_id)
         host_ids = self.get_hosts_with_same_cluster(host_id)
         if host_ids == []:
+            LOG.debug("host ids result %s", host_ids)
             return {}
         ip_map = {}
         self._hypervisor_details=""
@@ -3071,6 +3076,7 @@ class NovaProvider(Provider):
             # Make this as such only one request is used and then we parse it and get ips for different hosts
             ip_map[host]=self.get_ip_from_host_id(host)
             if not ip_map[host]:
+                LOG.debug("ip map result %s", ip_map)
                 return {}
 
         # Make nCr type combinations and choose amongst them randomly

--- a/hamgr/hamgr/providers/nova.py
+++ b/hamgr/hamgr/providers/nova.py
@@ -3061,6 +3061,7 @@ class NovaProvider(Provider):
 
     # Generate list of ips for vmha agent to monty
     def generate_ip_list(self, host_id):
+        LOG.info("handling request for host_id %s", host_id)
         host_ids = self.get_hosts_with_same_cluster(host_id)
         if host_ids == []:
             return {}
@@ -3083,6 +3084,7 @@ class NovaProvider(Provider):
                 picking_list[ind2]: ip_map[picking_list[ind2]],
                 picking_list[ind3]: ip_map[picking_list[ind3]],
             }
+            LOG.info("completed request for host_id %s", host_id)
             return final_map
             
             # Below is older implementation with combinations
@@ -3091,6 +3093,7 @@ class NovaProvider(Provider):
             #for key in ip_pool[randint(0,len(ip_pool)-1)]:
             #    final_map[key] = ip_map[key]
             #return final_map
+        LOG.info("completed request for host_id %s", host_id)
         return ip_map
     
     # Check from resmgr if the cluster has vmha enabled

--- a/hamgr/hamgr/providers/nova.py
+++ b/hamgr/hamgr/providers/nova.py
@@ -3030,6 +3030,7 @@ class NovaProvider(Provider):
         except requests.exceptions.Timeout:
             LOG.debug("request timed out %s", url)
             return host_ids
+        LOG.debug("request completed to %s", url)
         if response.status_code == 200:
             data = response.json()
             if 'aggregates' in data:
@@ -3053,6 +3054,7 @@ class NovaProvider(Provider):
             except requests.exceptions.Timeout:
                 LOG.debug("request timed out %s", url)
                 return ip
+            LOG.debug("request completed to %s", url)
             if response.status_code == 200:
                 data = response.json()
         else:
@@ -3060,7 +3062,8 @@ class NovaProvider(Provider):
         if 'hypervisors' in data:
             if len(data['hypervisors']) > 0:
                 ip = list(filter(lambda x:x['service']['host'] == host_id, data['hypervisors']))[0]['host_ip']
-        self.host_ip_to_id_map[host_id] = ip
+        if not ip:
+            self.host_ip_to_id_map[host_id] = ip
         return ip
 
     # Generate list of ips for vmha agent to monty

--- a/hamgr/hamgr/providers/nova.py
+++ b/hamgr/hamgr/providers/nova.py
@@ -52,8 +52,8 @@ AMQP_HOST_QUEUE_PREFIX = 'queue-receiving-for-host'
 AMQP_HTTP_PORT = 15672
 
 VMHA_MAX_FANOUT = 3
-VMHA_HOST_CACHE_INVALIDATION = 10*60
-# ^ 10 min for cache invalidation
+VMHA_HOST_CACHE_INVALIDATION = 5*60
+# ^ 5 min for cache invalidation
 VMHA_NOVA_DETAILS={"last_check":0, "response":{}}
 VMHA_OS_AGGREGATES={"last_check":0, "response":{}}
 
@@ -3016,10 +3016,10 @@ class NovaProvider(Provider):
         host_ids = []
         headers = {"X-AUTH-TOKEN": self._token['id']}
         url = 'http://nova-api.' + self._du_name + '.svc.cluster.local:8774/v2.1/os-aggregates'
-        flag=False
+        request_sent=False
         if time.time() - VMHA_OS_AGGREGATES["last_check"] > VMHA_HOST_CACHE_INVALIDATION or VMHA_OS_AGGREGATES["response"]=={}:
             LOG.debug("internal %s cache looks like %s", time.time(), VMHA_OS_AGGREGATES)
-            flag=True
+            request_sent=True
             try:
                 LOG.debug("request sent to %s", url)
                 response = requests.get(url, headers=headers,timeout=NOVA_REQ_TIMEOUT)
@@ -3027,7 +3027,7 @@ class NovaProvider(Provider):
                 LOG.debug("request timed out %s", url)
                 return host_ids
             LOG.debug("request completed with response %s", response.status_code)
-        if flag:
+        if request_sent:
             if response.status_code == 200:
                 data = response.json()
                 VMHA_OS_AGGREGATES["last_check"] = time.time()
@@ -3047,10 +3047,10 @@ class NovaProvider(Provider):
         headers = {"X-AUTH-TOKEN": self._token['id']}
         # We dont know whats the hypervisor id so be brute force it
         url = 'http://nova-api.' + self._du_name + '.svc.cluster.local:8774/v2.1/os-hypervisors/detail'
-        flag=False
+        request_sent=False
         if time.time() - VMHA_NOVA_DETAILS["last_check"] > VMHA_HOST_CACHE_INVALIDATION or VMHA_NOVA_DETAILS["response"]=={}:
             LOG.debug("internal %s cache looks like %s", time.time(), VMHA_NOVA_DETAILS)
-            flag=True
+            request_sent=True
             try:
                 LOG.debug("request sent to %s", url)
                 response = requests.get(url, headers=headers, timeout=NOVA_REQ_TIMEOUT)
@@ -3058,7 +3058,7 @@ class NovaProvider(Provider):
                 LOG.debug("request timed out %s", url)
                 return ip
             LOG.debug("request completed with response %s", response.status_code)
-        if flag:
+        if request_sent:
             if response.status_code == 200:
                 data = response.json()
                 VMHA_NOVA_DETAILS["last_check"] = time.time()

--- a/hamgr/hamgr/server.py
+++ b/hamgr/hamgr/server.py
@@ -58,7 +58,7 @@ def start_server(conf, paste_ini):
         #LOG.debug('add task process_consul_encryption_configuration')
         #periodic_task.add_task(provider.process_consul_encryption_configuration, 60, run_now=True)
         LOG.debug('add task process_availability_zone_changes')
-        periodic_task.add_task(provider.process_availability_zone_changes, 600, run_now=True)
+        periodic_task.add_task(provider.process_availability_zone_changes, 60, run_now=True)
         # dedicated task to handle host events
         LOG.debug('add task process_host_events')
         periodic_task.add_task(provider.process_host_events, 60, run_now=True)

--- a/hamgr/hamgr/server.py
+++ b/hamgr/hamgr/server.py
@@ -58,7 +58,7 @@ def start_server(conf, paste_ini):
         #LOG.debug('add task process_consul_encryption_configuration')
         #periodic_task.add_task(provider.process_consul_encryption_configuration, 60, run_now=True)
         LOG.debug('add task process_availability_zone_changes')
-        periodic_task.add_task(provider.process_availability_zone_changes, 180, run_now=True)
+        periodic_task.add_task(provider.process_availability_zone_changes, 600, run_now=True)
         # dedicated task to handle host events
         LOG.debug('add task process_host_events')
         periodic_task.add_task(provider.process_host_events, 60, run_now=True)

--- a/hamgr/hamgr/server.py
+++ b/hamgr/hamgr/server.py
@@ -58,7 +58,7 @@ def start_server(conf, paste_ini):
         #LOG.debug('add task process_consul_encryption_configuration')
         #periodic_task.add_task(provider.process_consul_encryption_configuration, 60, run_now=True)
         LOG.debug('add task process_availability_zone_changes')
-        periodic_task.add_task(provider.process_availability_zone_changes, 60, run_now=True)
+        periodic_task.add_task(provider.process_availability_zone_changes, 180, run_now=True)
         # dedicated task to handle host events
         LOG.debug('add task process_host_events')
         periodic_task.add_task(provider.process_host_events, 60, run_now=True)

--- a/hamgr/hamgr/wsgi.py
+++ b/hamgr/hamgr/wsgi.py
@@ -35,6 +35,16 @@ VMHA_TABLE={}
 MAX_FAILED_TIME = 180
 # ^ in sec
 
+version_payload = {
+   "versions":
+      {
+         "id":"v1",
+         "status":"CURRENT",
+         "version":"1.0",
+         "min_version":"1.0",
+      }
+}
+
 class MockEvent:
     def __init__(self, kwargs):
         for key, value in kwargs.items():
@@ -72,6 +82,11 @@ def get_providers_for_host(host_id, event_type):
     providers.append(nova_provider)
     
     return providers
+
+@app.route('/version', methods=['GET'])
+@error_handler
+def get_version():
+    return jsonify(version_payload)
 
 
 @app.route('/v1/ha', methods=['GET'])
@@ -425,7 +440,7 @@ def host_status_handler(host_id):
         else:
             VMHA_TABLE[host].append(True)
         # Remove older status to keep a queue of most recent statuses
-        if len(VMHA_TABLE[host]) >= 5:
+        if len(VMHA_TABLE[host]) >= 2:
             VMHA_TABLE[host].pop(0)
         LOG.debug(f"Cache looks like {VMHA_CACHE}. Table looks like this {VMHA_TABLE}")
         if VMHA_TABLE[host].count(True)-VMHA_TABLE[host].count(False) <= 0:

--- a/hamgr/hamgr/wsgi.py
+++ b/hamgr/hamgr/wsgi.py
@@ -32,7 +32,7 @@ CONTENT_TYPE_HEADER = {'Content-Type': 'application/json'}
 
 VMHA_CACHE = {}
 VMHA_TABLE={}
-MAX_FAILED_TIME = 180
+MAX_FAILED_TIME = 60
 # ^ in sec
 
 version_payload = {


### PR DESCRIPTION
<div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR fixes critical liveness probe issues by reducing the MAX_FAILED_TIME constant from 180 to 60 seconds in the hamgr system, enabling faster failure detection. It enhances the nova provider by refining the caching mechanism with module-level constants, adds detailed logging, and improves debug statements for cache state tracking. These changes improve system responsiveness, stability, and fault tolerance.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>