### PR TITLE
[MAIN]Increase timeout to 150sec

### DIFF
--- a/hamgr/hamgr/wsgi.py
+++ b/hamgr/hamgr/wsgi.py
@@ -32,7 +32,7 @@ CONTENT_TYPE_HEADER = {'Content-Type': 'application/json'}
 
 VMHA_CACHE = {}
 VMHA_TABLE={}
-MAX_FAILED_TIME = 60
+MAX_FAILED_TIME = 150
 # ^ in sec
 
 version_payload = {


### PR DESCRIPTION
<div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR increases the MAX_FAILED_TIME timeout value from 60 to 150 seconds in the wsgi module. The change allows the system to wait longer before registering failures, enhancing application stability during transient delays and improving overall operational resilience.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>