### PR TITLE
changed from nova api to resmgr and improved on caching logic

### DIFF
--- a/hamgr/hamgr/providers/nova.py
+++ b/hamgr/hamgr/providers/nova.py
@@ -3055,7 +3055,7 @@ class NovaProvider(Provider):
         ip=""
         headers = {"X-AUTH-TOKEN": self._token['id']}
         # We dont know whats the hypervisor id so be brute force it
-        url = 'http://nova-api.' + self._du_name + '.svc.cluster.local:8774/v2.1/os-hypervisors/detail'
+        url = 'http://resmgr.' + self._du_name + '.svc.cluster.local:18083/v2/hosts'
         request_sent=False
         if time.time() - VMHA_NOVA_DETAILS["last_check"] > VMHA_HOST_CACHE_INVALIDATION or VMHA_NOVA_DETAILS["response"]=={}:
             LOG.debug("internal %s cache looks like %s", time.time(), VMHA_NOVA_DETAILS)
@@ -3071,14 +3071,14 @@ class NovaProvider(Provider):
             if response.status_code == 200:
                 data = response.json()
                 VMHA_NOVA_DETAILS["last_check"] = time.time()
-                VMHA_NOVA_DETAILS["response"]=data
+                VMHA_NOVA_DETAILS["response"]=dict([ (x['id'],x) for x in data])
             else:
                 return ip
         else:
             data=VMHA_NOVA_DETAILS["response"]
-        if 'hypervisors' in data:
-            if len(data['hypervisors']) > 0:
-                ip = list(filter(lambda x:x['service']['host'] == host_id, data['hypervisors']))[0]['host_ip']
+
+        if len(data) > 0:
+            ip = data[host_id]['host_ip_mappings']['hostLivenessInterface']
         return ip
 
     # Generate list of ips for vmha agent to monty


### PR DESCRIPTION
##JIRA
[PCD-2200](https://platform9.atlassian.net/browse/PCD-2200)

##Related
https://github.com/platform9/pf9-du/pull/549


[PCD-2200]: https://platform9.atlassian.net/browse/PCD-2200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request updates the nova provider module by replacing the old nova API endpoint with a new resmgr URL. It transforms the API response into a dictionary and reworks the logic to extract host IP, improving reliability and performance of data retrieval. The changes enhance hypervisor details management and caching.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>